### PR TITLE
Change method to PATCH

### DIFF
--- a/src/clients/contact-client.js
+++ b/src/clients/contact-client.js
@@ -23,8 +23,11 @@ class ContactClient {
     return this.client.create(data, parameters)
   }
 
-  update (id, data, parameters = {}) {
-    return this.client.update(id, data, parameters)
+  update (id, data) {
+    return this.client.sendRequest(`${this.client.baseUrl}/${id}`, {
+      body: data,
+      method: 'PATCH'
+    })
   }
 
   destroy (id, parameters = {}) {


### PR DESCRIPTION
Small change I haven't noticed before. By default `base-client` uses `PUT` for `update` but in the case of `contact-service` `PATCH` has to be used. See related code: [ContactStore - onUpdate](https://github.com/infopark-customers/bima-meinebima2/blob/42ef9a711b6ca4f983332f389ef6a3d936038fbc/client/src/stores/contact/store.js#L52)