### PR TITLE
Feature/upload progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bima-shark-sdk",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "standard": {
     "globals": [
-      "fetch"
+      "fetch",
+      "XMLHttpRequest"
     ],
     "ignore": [
       "/dist/*.js"

--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
   },
   "standard": {
     "globals": [
-      "fetch",
-      "XMLHttpRequest",
-      "FormData",
-      "File"
     ],
     "ignore": [
       "/dist/*.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "standard": {
     "globals": [
       "fetch",
-      "XMLHttpRequest"
+      "XMLHttpRequest",
+      "FormData",
+      "File"
     ],
     "ignore": [
       "/dist/*.js"

--- a/shark-browser.js
+++ b/shark-browser.js
@@ -14,7 +14,7 @@ Object.assign(sharkFetch, {
 /*
  * Configure shark-upload-file with Browser implementation
  */
-const { uploadFileBrowser } = require('./src/utils/upload-file')
+const uploadFileBrowser = require('./src/utils/upload-file-browser')
 const sharkUploadFile = require('./src/utils/shark-upload-file')
 Object.assign(sharkUploadFile, {
   uploadFile: uploadFileBrowser

--- a/shark-browser.js
+++ b/shark-browser.js
@@ -12,6 +12,15 @@ Object.assign(sharkFetch, {
 })
 
 /*
+ * Configure shark-upload-file with Browser implementation
+ */
+const { uploadFileBrowser } = require('./src/utils/upload-file')
+const sharkUploadFile = require('./src/utils/shark-upload-file')
+Object.assign(sharkUploadFile, {
+  uploadFile: uploadFileBrowser
+})
+
+/*
  * Expose Shark clients
  */
 const Shark = require('./src/shark')

--- a/shark-node.js
+++ b/shark-node.js
@@ -17,7 +17,7 @@ Object.assign(sharkFetch, {
 /*
  * Configure shark-upload-file with Browser implementation
  */
-const { uploadFileNode } = require('./src/utils/upload-file')
+const uploadFileNode = require('./src/utils/upload-file-node')
 const sharkUploadFile = require('./src/utils/shark-upload-file')
 Object.assign(sharkUploadFile, {
   uploadFile: uploadFileNode

--- a/shark-node.js
+++ b/shark-node.js
@@ -15,6 +15,15 @@ Object.assign(sharkFetch, {
 })
 
 /*
+ * Configure shark-upload-file with Browser implementation
+ */
+const { uploadFileNode } = require('./src/utils/upload-file')
+const sharkUploadFile = require('./src/utils/shark-upload-file')
+Object.assign(sharkUploadFile, {
+  uploadFile: uploadFileNode
+})
+
+/*
  * Expose Shark clients
  */
 const Shark = require('./src/shark')

--- a/src/clients/asset-client.js
+++ b/src/clients/asset-client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Client = require('./base-client')
-const uploadFile = require('../utils/shark-upload-file')
+const { uploadFile } = require('../utils/shark-upload-file')
 const mime = require('mime/lite')
 
 class AssetClient {

--- a/src/clients/asset-client.js
+++ b/src/clients/asset-client.js
@@ -14,12 +14,12 @@ class AssetClient {
     this.directory = directory
   }
 
-  create (file, parameters = {}) {
+  create (file, options = {}) {
     return this.__createOrUpdate({
       method: 'POST',
       url: `${this.client.baseUrl}`,
       file: file,
-      onProgress: parameters.onProgress
+      onProgress: options.onProgress
     })
   }
 
@@ -35,12 +35,12 @@ class AssetClient {
     return this.client.find(id, parameters)
   }
 
-  update (file, id, parameters = {}) {
+  update (file, id, options = {}) {
     return this.__createOrUpdate({
       method: 'PUT',
       url: `${this.client.baseUrl}/${id}`,
       file: file,
-      onProgress: parameters.onProgress
+      onProgress: options.onProgress
     })
   }
 
@@ -56,8 +56,8 @@ class AssetClient {
     })
   }
 
-  __createOrUpdate (parameters = {}) {
-    const fileName = parameters.file.name
+  __createOrUpdate (options = {}) {
+    const fileName = options.file.name
     const data = {
       data: {
         type: 'assets',
@@ -68,8 +68,8 @@ class AssetClient {
       }
     }
 
-    return this.client.sendRequest(parameters.url, {
-      method: parameters.method,
+    return this.client.sendRequest(options.url, {
+      method: options.method,
       body: data
     }).then(response => {
       const id = response.data.id
@@ -79,8 +79,8 @@ class AssetClient {
       return uploadFile({
         uploadUrl: uploadUrl,
         fileMimeType: fileMimeType,
-        file: parameters.file,
-        onProgress: parameters.onProgress
+        file: options.file,
+        onProgress: options.onProgress
       }).then(() => {
         return this.find(id).then(asset => {
           return asset

--- a/src/clients/base-client.js
+++ b/src/clients/base-client.js
@@ -2,7 +2,7 @@
 
 const param = require('jquery-param')
 const { isString } = require('../utils/typecheck')
-const simpleFetch = require('../utils/simple-fetch')
+const { simpleFetch } = require('../utils/simple-fetch')
 const ServiceTokenClient = require('../service-token/browser')
 
 // TODO hack empty arrays?

--- a/src/service-token/browser.js
+++ b/src/service-token/browser.js
@@ -4,7 +4,7 @@ const Config = require('../config')
 const Cache = require('../cache')
 const Deserializer = require('../jsonapi-serializer/deserializer')
 const { isString } = require('../utils/typecheck')
-const simpleFetch = require('../utils/simple-fetch')
+const { simpleFetch } = require('../utils/simple-fetch')
 
 const deserializer = new Deserializer({ keyForAttribute: 'camelCase' })
 

--- a/src/utils/shark-upload-file.js
+++ b/src/utils/shark-upload-file.js
@@ -1,0 +1,7 @@
+'use strict'
+
+/**
+ * Must be configured before using bima-shark-sdk.
+ * That's usually done in the entry points shark-browser.js and shark-node.js.
+ */
+module.exports = {}

--- a/src/utils/signed-fetch.js
+++ b/src/utils/signed-fetch.js
@@ -5,7 +5,7 @@ const URL = require('url')
 
 const { Headers } = require('./shark-fetch')
 const { isString } = require('./typecheck')
-const simpleFetch = require('./simple-fetch')
+const { simpleFetch } = require('./simple-fetch')
 
 function md5Base64digest (data) {
   return crypto.createHash('md5')

--- a/src/utils/simple-fetch.js
+++ b/src/utils/simple-fetch.js
@@ -114,4 +114,7 @@ function jsonApiError (response) {
   return new Error(errors)
 }
 
-module.exports = simpleFetch
+module.exports = {
+  simpleFetch,
+  jsonApiError
+}

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports.uploadFileBrowser = (options = {}) => {
+const uploadFileBrowser = (options = {}) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     xhr.open('PUT', options.uploadUrl)
@@ -17,3 +17,5 @@ module.exports.uploadFileBrowser = (options = {}) => {
     xhr.send(options.file)
   })
 }
+
+module.exports = uploadFileBrowser

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -6,7 +6,7 @@ const uploadFileBrowser = (options = {}) => {
     xhr.open('PUT', options.uploadUrl)
     xhr.setRequestHeader('Content-Type', options.fileMimeType || '')
     xhr.responseType = 'json'
-    xhr.onprogress = options.onProgress
+    xhr.upload.onprogress = options.onProgress
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve(xhr.response)

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { jsonApiError } = require('./simple-fetch')
+
 const uploadFileBrowser = (options = {}) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
@@ -11,7 +13,8 @@ const uploadFileBrowser = (options = {}) => {
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve(xhr.response)
       } else {
-        reject(xhr.statusText)
+        const error = jsonApiError(xhr)
+        return reject(error)
       }
     }
     xhr.send(options.file)

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -4,7 +4,7 @@ const { jsonApiError } = require('./simple-fetch')
 
 const uploadFileBrowser = (options = {}) => {
   return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest()
+    const xhr = new window.XMLHttpRequest()
     xhr.open('PUT', options.uploadUrl)
     xhr.setRequestHeader('Content-Type', options.fileMimeType || '')
     xhr.responseType = 'json'

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { simpleFetch } = require('./simple-fetch')
-
 module.exports.uploadFileBrowser = (options = {}) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
@@ -17,15 +15,5 @@ module.exports.uploadFileBrowser = (options = {}) => {
       }
     }
     xhr.send(options.file)
-  })
-}
-
-module.exports.uploadFileNode = (options = {}) => {
-  return simpleFetch(options.uploadUrl, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': options.fileMimeType || ''
-    },
-    body: options.file
   })
 }

--- a/src/utils/upload-file-node.js
+++ b/src/utils/upload-file-node.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const simpleFetch = require('./simple-fetch')
+const { simpleFetch } = require('./simple-fetch')
 
 const uploadFileNode = (options = {}) => {
   return simpleFetch(options.uploadUrl, {

--- a/src/utils/upload-file-node.js
+++ b/src/utils/upload-file-node.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { simpleFetch } = require('./simple-fetch')
+
+module.exports.uploadFileNode = (options = {}) => {
+  return simpleFetch(options.uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': options.fileMimeType || ''
+    },
+    body: options.file
+  })
+}

--- a/src/utils/upload-file-node.js
+++ b/src/utils/upload-file-node.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { simpleFetch } = require('./simple-fetch')
+const simpleFetch = require('./simple-fetch')
 
-module.exports.uploadFileNode = (options = {}) => {
+const uploadFileNode = (options = {}) => {
   return simpleFetch(options.uploadUrl, {
     method: 'PUT',
     headers: {
@@ -11,3 +11,5 @@ module.exports.uploadFileNode = (options = {}) => {
     body: options.file
   })
 }
+
+module.exports = uploadFileNode

--- a/src/utils/upload-file.js
+++ b/src/utils/upload-file.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { simpleFetch } = require('./simple-fetch')
+
+module.exports.uploadFileBrowser = (parameters = {}) => {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('PUT', parameters.uploadUrl)
+    xhr.setRequestHeader('Content-Type', parameters.fileMimeType || '')
+    xhr.onprogress = parameters.onProgress
+    xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(xhr.response)
+      } else {
+          reject(xhr.statusText)
+      }
+    }
+    xhr.send(parameters.file)
+  })
+}
+
+module.exports.uploadFileNode = (parameters = {}) => {
+  return simpleFetch(parameters.uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': parameters.fileMimeType || ''
+    },
+    body: parameters.file
+  })
+}

--- a/src/utils/upload-file.js
+++ b/src/utils/upload-file.js
@@ -2,12 +2,12 @@
 
 const { simpleFetch } = require('./simple-fetch')
 
-module.exports.uploadFileBrowser = (parameters = {}) => {
+module.exports.uploadFileBrowser = (options = {}) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
-    xhr.open('PUT', parameters.uploadUrl)
-    xhr.setRequestHeader('Content-Type', parameters.fileMimeType || '')
-    xhr.onprogress = parameters.onProgress
+    xhr.open('PUT', options.uploadUrl)
+    xhr.setRequestHeader('Content-Type', options.fileMimeType || '')
+    xhr.onprogress = options.onProgress
     xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           resolve(xhr.response)
@@ -15,16 +15,16 @@ module.exports.uploadFileBrowser = (parameters = {}) => {
           reject(xhr.statusText)
       }
     }
-    xhr.send(parameters.file)
+    xhr.send(options.file)
   })
 }
 
-module.exports.uploadFileNode = (parameters = {}) => {
-  return simpleFetch(parameters.uploadUrl, {
+module.exports.uploadFileNode = (options = {}) => {
+  return simpleFetch(options.uploadUrl, {
     method: 'PUT',
     headers: {
-      'Content-Type': parameters.fileMimeType || ''
+      'Content-Type': options.fileMimeType || ''
     },
-    body: parameters.file
+    body: options.file
   })
 }

--- a/src/utils/upload-file.js
+++ b/src/utils/upload-file.js
@@ -7,12 +7,13 @@ module.exports.uploadFileBrowser = (options = {}) => {
     const xhr = new XMLHttpRequest()
     xhr.open('PUT', options.uploadUrl)
     xhr.setRequestHeader('Content-Type', options.fileMimeType || '')
+    xhr.responseType = 'json'
     xhr.onprogress = options.onProgress
     xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(xhr.response)
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(xhr.response)
       } else {
-          reject(xhr.statusText)
+        reject(xhr.statusText)
       }
     }
     xhr.send(options.file)

--- a/test/clients/base-client-test.js
+++ b/test/clients/base-client-test.js
@@ -266,8 +266,8 @@ describe('Client with successful service token', () => {
       })
 
       it('should return empty body', (done) => {
-        const formData = new FormData()
-        formData.append('file', new File([''], 'filename', { type: 'text/html' }))
+        const formData = new window.FormData()
+        formData.append('file', new window.File([''], 'filename', { type: 'text/html' }))
         const promise = client.uploadFile('1/file', formData)
         promise.then(body => {
           expect(body).to.eql({})

--- a/test/clients/base-client-test.js
+++ b/test/clients/base-client-test.js
@@ -252,6 +252,30 @@ describe('Client with successful service token', () => {
       })
     })
   })
+
+  describe('#uploadFile', () => {
+    describe('on success 204 without body', () => {
+      beforeEach(() => {
+        mockFetch({
+          method: 'POST',
+          host: CLIENT_URL,
+          path: '/1/file',
+          responseBody: null,
+          status: 204
+        })
+      })
+
+      it('should return empty body', (done) => {
+        const formData = new FormData()
+        formData.append('file', new File([''], 'filename', { type: 'text/html' }))
+        const promise = client.uploadFile('1/file', formData)
+        promise.then(body => {
+          expect(body).to.eql({})
+          done()
+        })
+      })
+    })
+  })
 })
 
 describe('Client with failed service tokens', () => {

--- a/test/utils/upload-file-node-test.js
+++ b/test/utils/upload-file-node-test.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const nock = require('nock')
+const uploadFileNode = require('../../src/utils/upload-file-node')
+const sharkUploadFile = require('../../src/utils/shark-upload-file')
+Object.assign(sharkUploadFile, {
+  uploadFile: uploadFileNode
+})
+
+const UPLOAD_URL = 'https://upload-url.example.com'
+
+const mockFetch = () => {
+  nock(UPLOAD_URL)
+    .put('/uploads')
+    .reply(204, null)
+}
+
+describe('#uploadFile', () => {
+  beforeEach(() => {
+    mockFetch()
+  })
+
+  it('returns empty body', () => {
+    const fileMimeType = 'text/html'
+    const file = new File([''], 'filename', { type: fileMimeType })
+    const promise = sharkUploadFile.uploadFile({
+      uploadUrl: `${UPLOAD_URL}/uploads`,
+      fileMimeType: fileMimeType,
+      file: file
+    })
+
+    promise.then(body => {
+      expect(body).to.eql({})
+    })
+  })
+})

--- a/test/utils/upload-file-node-test.js
+++ b/test/utils/upload-file-node-test.js
@@ -24,7 +24,7 @@ describe('#uploadFile', () => {
 
   it('returns empty body', () => {
     const fileMimeType = 'text/html'
-    const file = new File([''], 'filename', { type: fileMimeType })
+    const file = new window.File([''], 'filename', { type: fileMimeType })
     const promise = sharkUploadFile.uploadFile({
       uploadUrl: `${UPLOAD_URL}/uploads`,
       fileMimeType: fileMimeType,


### PR DESCRIPTION
Update progress for `AssetClient` `create` and `update` methods. This functionality consists of two implementations one for `node` which basically uses the previous upload code and another for `browser` using `XMLHttpRequest` available within the browser to provide upload progress. `uploadFile` function accepts `onProgress` option to pass progress function. One thing I'd like to point out bout this function is its name. It concerns me a bit cause some time ago I implemented `uploadFile` for `BaseClient` to be able to upload avatar. I think we might think on a different name for this function to avoid any collisions.

I haven't written tests for browser implementation cause I'm not sure how to approach this e.g. use headless browser or mock `XHR`? So I'm happy to accept any suggestions about that cause I definitely want to test it. However, I've tested it with `milaCRM` and it seems to be working just fine.

- [x] implement uploadFile with progress

- [ ] test browser `XHR` implementation