### PR TITLE
Feature/nick client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,7 +3111,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3132,12 +3133,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3152,17 +3155,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3279,7 +3285,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3291,6 +3298,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3305,6 +3313,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3312,12 +3321,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3336,6 +3347,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3416,7 +3428,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3428,6 +3441,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3513,7 +3527,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3549,6 +3564,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3568,6 +3584,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3611,12 +3628,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/shark-browser.js
+++ b/shark-browser.js
@@ -42,6 +42,7 @@ Shark.NotificationsClient = require('./src/clients/notifications-client')
 Shark.ServiceTokenClient = require('./src/service-token/browser')
 Shark.SubscriptionClient = require('./src/clients/subscription-client')
 Shark.UserClient = require('./src/clients/user-client')
+Shark.NickClient = require('./src/clients/nick-client')
 Shark.fetch = require('./src/utils/simple-fetch')
 Shark.isArray = isArray
 Shark.isFunction = isFunction

--- a/src/clients/base-browser-client.js
+++ b/src/clients/base-browser-client.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const param = require('jquery-param')
-
 const { isString } = require('../utils/typecheck')
+const { buildUrl } = require('../utils/url-helper')
 const simpleFetch = require('../utils/simple-fetch')
 
 const BaseClient = require('./base-client')
@@ -79,7 +78,7 @@ class Client extends BaseClient {
    * @return {promise} the uploadFile promise
    */
   uploadFile (path, data, parameters = {}) {
-    const url = this.__buildUrl(path, parameters)
+    const url = buildUrl(this.baseUrl, path, parameters)
     const opts = {
       headers: {},
       body: data,
@@ -96,20 +95,6 @@ class Client extends BaseClient {
       opts.credentials = 'same-origin'
       return simpleFetch(url, opts)
     }
-  }
-
-  buildUrl (path, parameters) {
-    let url = this.baseUrl
-    let urlPath = path || ''
-    let queryString = param(parameters)
-
-    if (url.slice(-1) !== '/') { url += '/' }
-    urlPath = urlPath.toString()
-    if (urlPath[0] === '/') { urlPath = urlPath.slice(1) }
-    url += urlPath
-    if (queryString.length > 0) { url += `?${queryString}` }
-
-    return url
   }
 }
 

--- a/src/clients/base-browser-client.js
+++ b/src/clients/base-browser-client.js
@@ -98,7 +98,7 @@ class Client extends BaseClient {
     }
   }
 
-  __buildUrl (path, parameters) {
+  buildUrl (path, parameters) {
     let url = this.baseUrl
     let urlPath = path || ''
     let queryString = param(parameters)

--- a/src/clients/base-client.js
+++ b/src/clients/base-client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const param = require('jquery-param')
+const { buildUrl } = require('../utils/url-helper')
 
 /**
  * @class Client
@@ -15,7 +15,7 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   search (parameters = {}) {
-    const url = this.__buildUrl(null, parameters)
+    const url = buildUrl(this.baseUrl, null, parameters)
     return this.sendRequest(url)
   }
 
@@ -26,7 +26,7 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   find (id, parameters = {}) {
-    const url = this.__buildUrl(id, parameters)
+    const url = buildUrl(this.baseUrl, id, parameters)
     return this.sendRequest(url)
   }
 
@@ -37,7 +37,7 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   create (data, parameters = {}) {
-    const url = this.__buildUrl(null, parameters)
+    const url = buildUrl(this.baseUrl, null, parameters)
 
     return this.sendRequest(url, {
       body: data,
@@ -53,7 +53,7 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   update (id, data, parameters = {}) {
-    const url = this.__buildUrl(id, parameters)
+    const url = buildUrl(this.baseUrl, id, parameters)
 
     return this.sendRequest(url, {
       body: data,
@@ -69,7 +69,7 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   patch (id, data, parameters = {}) {
-    const url = this.__buildUrl(id, parameters)
+    const url = buildUrl(this.baseUrl, id, parameters)
 
     return this.sendRequest(url, {
       body: data,
@@ -84,24 +84,10 @@ class BaseClient {
    * @return {promise} The request promise.
    */
   destroy (id, parameters = {}) {
-    const url = this.__buildUrl(id, parameters)
+    const url = buildUrl(this.baseUrl, id, parameters)
     return this.sendRequest(url, {
       method: 'DELETE'
     })
-  }
-
-  __buildUrl (path, parameters) {
-    let url = this.baseUrl
-    let urlPath = path || ''
-    let queryString = param(parameters)
-
-    if (url.slice(-1) !== '/') { url += '/' }
-    urlPath = urlPath.toString()
-    if (urlPath[0] === '/') { urlPath = urlPath.slice(1) }
-    url += urlPath
-    if (queryString.length > 0) { url += `?${queryString}` }
-
-    return url
   }
 }
 

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { buildUrl } = require('../utils/url-helper')
 const Client = require('./base-browser-client')
 
 class NickClient {
@@ -12,27 +13,27 @@ class NickClient {
   }
 
   index (type, parameters = {}) {
-    let url = this.client.buildUrl(type, parameters)
+    let url = buildUrl(this.client.baseUrl, type, parameters)
     return this.client.sendRequest(url, { method: 'GET' })
   }
 
   find (type, id, parameters = {}) {
-    let url = this.client.buildUrl(`${type}/${id}`, parameters)
+    let url = buildUrl(this.client.baseUrl, `${type}/${id}`, parameters)
     return this.client.sendRequest(url, { method: 'GET' })
   }
 
   create (type, data, parameters = {}) {
-    let url = this.client.buildUrl(type, parameters)
+    let url = buildUrl(this.client.baseUrl, type, parameters)
     return this.client.sendRequest(url, { body: data, method: 'POST' })
   }
 
   update (type, id, data, parameters = {}) {
-    let url = this.client.buildUrl(`${type}/${id}`, parameters)
+    let url = buildUrl(this.client.baseUrl, `${type}/${id}`, parameters)
     return this.client.sendRequest(url, { body: data, method: 'PUT' })
   }
 
   destroy (type, id, parameters = {}) {
-    let url = this.client.buildUrl(`${type}/${id}`, parameters)
+    let url = buildUrl(this.client.baseUrl, `${type}/${id}`, parameters)
     return this.sendRequest(url, { method: 'DELETE' })
   }
 }

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -11,28 +11,28 @@ class NickClient {
     })
   }
 
-  index (type) {
-    let url = `${this.client.baseUrl}/${type}`
+  index (type, parameters = {}) {
+    let url = this.client.buildUrl(type, parameters)
     return this.client.sendRequest(url, { method: 'GET' })
   }
 
-  find (type, id) {
-    let url = `${this.client.baseUrl}/${type}/${id}`
+  find (type, id, parameters = {}) {
+    let url = this.client.buildUrl(`${type}/${id}`, parameters)
     return this.client.sendRequest(url, { method: 'GET' })
   }
 
-  create (type, data) {
-    let url = `${this.client.baseUrl}/${type}`
+  create (type, data, parameters = {}) {
+    let url = this.client.buildUrl(type, parameters)
     return this.client.sendRequest(url, { body: data, method: 'POST' })
   }
 
-  update (type, id, data) {
-    let url = `${this.client.baseUrl}/${type}/${id}`
+  update (type, id, data, parameters = {}) {
+    let url = this.client.buildUrl(`${type}/${id}`, parameters)
     return this.client.sendRequest(url, { body: data, method: 'PUT' })
   }
 
   destroy (type, id, parameters = {}) {
-    let url = `${this.client.baseUrl}/${type}/${id}`
+    let url = this.client.buildUrl(`${type}/${id}`, parameters)
     return this.sendRequest(url, { method: 'DELETE' })
   }
 }

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const Client = require('./base-browser-client')
+
+class NickClient {
+  constructor (url) {
+    this.client = new Client({
+      name: 'NickClient',
+      url: `${url}`,
+      contentType: 'application/vnd.api+json'
+    })
+  }
+
+  index (type) {
+    let url = `${this.client.baseUrl}/${type}`
+    return this.client.sendRequest(url, { method: 'GET' })
+  }
+
+  find (type, id) {
+    let url = `${this.client.baseUrl}/${type}/${id}`
+    return this.client.sendRequest(url, { method: 'GET' })
+  }
+
+  create (type, data) {
+    let url = `${this.client.baseUrl}/${type}`
+    return this.client.sendRequest(url, { body: data, method: 'POST' })
+  }
+
+  update (type, id, data) {
+    let url = `${this.client.baseUrl}/${type}/${id}`
+    return this.client.sendRequest(url, { body: data, method: 'PUT' })
+  }
+
+  destroy (type, id, parameters = {}) {
+    let url = `${this.client.baseUrl}/${type}/${id}`
+    return this.sendRequest(url, { method: 'DELETE' })
+  }
+}
+
+module.exports = NickClient

--- a/src/utils/upload-file-browser.js
+++ b/src/utils/upload-file-browser.js
@@ -4,7 +4,6 @@ const { jsonApiError } = require('./response-helper')
 const { isFunction } = require('./typecheck')
 
 const uploadFileBrowser = (options = {}) => {
-
   return new Promise((resolve, reject) => {
     const xhr = new window.XMLHttpRequest()
     xhr.open('PUT', options.uploadUrl)

--- a/src/utils/url-helper.js
+++ b/src/utils/url-helper.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const param = require('jquery-param')
+
+module.exports.buildUrl = (baseUrl, path, parameters) => {
+  let url = baseUrl
+  let urlPath = path || ''
+  let queryString = param(parameters)
+
+  if (url.slice(-1) !== '/') { url += '/' }
+  urlPath = urlPath.toString()
+  if (urlPath[0] === '/') { urlPath = urlPath.slice(1) }
+  url += urlPath
+  if (queryString.length > 0) { url += `?${queryString}` }
+
+  return url
+}


### PR DESCRIPTION
Nick client for JS which supports all CRUD operations of the nick API.

Since some client need more control over the url, such as the construction of the full JSON resource identifier object based on type and object ID. Therefore the buildUrl became public function instead of private, so the function did not had to be reimplemented or duplicated. The is a non-breaking-change (NBC) so no worries here.