### PR TITLE
Feature/node service token caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+cache: npm
+node_js:
+  - "8"
+
+before_install:
+  - npm i -g npm@latest
+  - npm i -g standard
+
+script:
+  - jest
+  - standard

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Add your own `fetch` library.
 * for browsers use [whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch) as polyfill for Internet Explorer
 * in AWS Lambda functions use [node-fetch](https://www.npmjs.com/package/node-fetch)
 
-> In browser enviroments:
+> In pure browser enviroments without webpack:
 > - run `npm run build`
 > - copy ` dist/bima-shark-sdk.js ` into your app.
 
+
 ### Usage
 
-#### Configuration (optional)
+#### In browser
 
-```
+```js
 import Shark from 'bima-shark-sdk'
 
 Shark.configure({
@@ -38,13 +39,45 @@ Shark.configure({
 })
 
 import { UserClient } from 'bima-shark-sdk'
+
+const client = new UserClient('https://doorkeeper-development.bundesimmo.de')
+client.find(123)
+  .then(
+    json => { console.log('Success: ', json) },
+    err => { console.log('Error: ', err) }
+  ).finally(
+    () => { console.log('Hide loader') }
+  )
 ```
+
+#### In node.js
+
+```js
+const { MailingClient } = require('bima-shark-sdk')
+
+const client = new MailingClient('https://mailing-development.bundesimmo.de', {
+  serviceToken: {
+    baseUrl: 'https://doorkeeper-development.bundesimmo.de',
+    accessKey: 'your-access-key',
+    secretKey: 'your-secret-key',
+    userId: '1234567890'  // optional
+  }
+})
+
+client.create({ foo: 'bar' })
+  .then(
+    json => { console.log('Success: ', json) },
+    err => { console.log('Error: ', err) }
+  )
+```
+
 
 ### Testing
 
-This SDK uses [Mocha](https://mochajs.org/) as test framework. Server responses are mocked with [nock](https://www.npmjs.com/package/nock).
+This SDK uses [jest](https://jestjs.io/) as test framework. Server responses are mocked with [nock](https://www.npmjs.com/package/nock).
 
 ```
+npm ci
 npm test
 ```
 

--- a/src/browser/service-token.js
+++ b/src/browser/service-token.js
@@ -22,7 +22,7 @@ class ServiceTokenClient {
     this.baseUrl = options.baseUrl
 
     if (!isString(this.baseUrl)) {
-      throw new Error('Parameter `baseUrl` is missing or not a string')
+      throw new Error('Key `baseUrl` in `options` parameter is missing or not a string')
     }
   }
 
@@ -37,16 +37,25 @@ class ServiceTokenClient {
       let now = new Date()
       let date = new Date(token.expiresAt)
       if (date < now) {
-        return this.__request()
+        return this.request()
       } else {
         return Promise.resolve(token)
       }
     } else {
-      return this.__request()
+      return this.request()
     }
   }
 
-  __request () {
+  /**
+   * Verifies if a service token is still valid.
+   *
+    * @throws {Error}
+   */
+  verifyServiceToken (params, options = {}) {
+    throw new Error('ServiceTokenClient does not implement #verifyServiceToken for browser enviroments')
+  }
+
+  request () {
     const cacheKey = this.cacheKey()
     const csrfToken = this.csrfToken()
 

--- a/src/clients/mailing-client.js
+++ b/src/clients/mailing-client.js
@@ -7,11 +7,7 @@ class MailingClient {
     this.client = new Client({
       name: 'MailingClient',
       url: `${url}/v1/mails`,
-      serviceToken: options.serviceToken || {
-        accessKey: options.accessKey,
-        secretKey: options.secretKey,
-        baseUrl: options.doorkeeperBaseUrl
-      }
+      serviceToken: options.serviceToken
     })
   }
 

--- a/src/node/service-token.js
+++ b/src/node/service-token.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const param = require('jquery-param')
+const Cache = require('../cache')
 const Deserializer = require('../jsonapi-serializer/deserializer')
 const { isString } = require('../utils/typecheck')
 const signedFetch = require('../utils/signed-fetch')
@@ -15,11 +16,12 @@ const deserializer = new Deserializer({ keyForAttribute: 'camelCase' })
  *   - accessKey {string}
  *   - secretKey {string}
  *   - baseUrl {string}
- *   - digest {string}
+ *   - digest {string} (defaults to 'sha1')
+ *   - userId {string}
  *
  * @throws {Error} if baseUrl is invalid
- * @throws {Error} if accessKey cannot be instantiated
- * @throws {Error} if secretKey cannot be instantiated
+ * @throws {Error} if accessKey is invalid
+ * @throws {Error} if secretKey is invalid
  */
 class ServiceTokenClient {
   constructor (options = {}) {
@@ -29,14 +31,16 @@ class ServiceTokenClient {
     this.baseUrl = options.baseUrl
 
     if (!isString(this.baseUrl)) {
-      throw new Error('Parameter `baseUrl` is missing or not a string')
+      throw new Error('Key `baseUrl` in `options` parameter is missing or not a string')
     }
     if (!isString(this.accessKey)) {
-      throw new Error('Parameter `accessKey` is missing or not a string')
+      throw new Error('Key `accessKey` in `options` parameter is missing or not a string')
     }
     if (!isString(this.secretKey)) {
-      throw new Error('Parameter `secretKey` is missing or not a string')
+      throw new Error('Key `secretKey` in `options` parameter is missing or not a string')
     }
+
+    this.userId = options.userId
   }
 
   /**
@@ -44,18 +48,21 @@ class ServiceTokenClient {
    *
    * @return {Promise} the fetch promise
    */
-  createServiceToken (params, options = {}) {
-    const url = `${this.baseUrl}/api/tokens/service_token`
-    const { userId, customClaims } = params
-    const requestOptions = Object.assign({
-      method: 'POST',
-      body: {
-        user_id: userId,
-        custom_claims: customClaims || {}
-      }
-    }, options)
+  createServiceToken (options = {}) {
+    const cacheKey = this.cacheKey()
+    const token = Cache.lookup(cacheKey)
 
-    return this.__request(url, requestOptions)
+    if (token && token.expiresAt) {
+      let now = new Date()
+      let date = new Date(token.expiresAt)
+      if (date < now) {
+        return this.requestServiceToken(options)
+      } else {
+        return Promise.resolve(token)
+      }
+    } else {
+      return this.requestServiceToken(options)
+    }
   }
 
   /**
@@ -73,10 +80,28 @@ class ServiceTokenClient {
       method: 'GET'
     }, options)
 
-    return this.__request(url, requestOptions)
+    return this.signedRequest(url, requestOptions)
   }
 
-  __request (url, options = {}) {
+  requestServiceToken (options = {}) {
+    const cacheKey = this.cacheKey()
+    Cache.remove(cacheKey)
+
+    const url = `${this.baseUrl}/api/tokens/service_token`
+    const requestOptions = Object.assign({
+      method: 'POST',
+      body: {
+        user_id: this.userId
+      }
+    }, options)
+
+    return this.signedRequest(url, requestOptions).then(token => {
+      Cache.store(cacheKey, token)
+      return token
+    })
+  }
+
+  signedRequest (url, options = {}) {
     const headers = Object.assign({
       'content-type': 'application/vnd.api+json'
     }, options.headers || {})
@@ -90,6 +115,10 @@ class ServiceTokenClient {
     return signedFetch(url, requestOptions).then(json => {
       return deserializer.deserialize(json)
     })
+  }
+
+  cacheKey () {
+    return `api-service-token/${this.userId}`
   }
 }
 

--- a/test/node/base-client.test.js
+++ b/test/node/base-client.test.js
@@ -8,8 +8,7 @@ const {
   SERVICE_TOKEN_RESPONSE_BODY,
   CLIENT_URL,
   DOORKEEPER_BASE_URL,
-  JWT,
-  teardown
+  JWT
 } = require('./test-helper')
 
 const SharkProxy = require('../../src/proxy')
@@ -70,7 +69,7 @@ describe('Node version: BaseClient with successful service token', () => {
     })
   })
   afterEach(() => {
-    teardown()
+    nock.cleanAll()
   })
 
   describe('#baseUrl', () => {

--- a/test/node/test-helper.js
+++ b/test/node/test-helper.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 'use strict'
 
-const nock = require('nock')
 const nodeFetch = require('node-fetch')
 
 const SharkProxy = require('../../src/proxy')
@@ -44,16 +43,11 @@ const USER_RESPONSE_BODY = {
   }
 }
 
-function teardown () {
-  nock.cleanAll()
-}
-
 module.exports = {
   BODY,
   CLIENT_URL,
   DOORKEEPER_BASE_URL,
   JWT,
   USER_RESPONSE_BODY,
-  SERVICE_TOKEN_RESPONSE_BODY,
-  teardown
+  SERVICE_TOKEN_RESPONSE_BODY
 }


### PR DESCRIPTION
Implements the features missing in the last PR. Contains breaking changes, that will be in the Changelog later on.

features:
* create service tokens for specific userId in node.js
* add service token caching for node.js
* travis integration hopefully

breaking changes:
* `MailingClient` constructor use `serviceToken` as option and not { accessToken: ' ', secretKey: ' ', ... }`
* [break] `ServiceToken#createServiceToken` takes no params anymore, add `userId` when creating a new client