### PR TITLE
Add asset creation NickClient - Asset upload Part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- [new] `NickClient` add support for asset creation
+
 #### 2.2.0
 - [new] `NickClient` supports userinfo
 

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -94,6 +94,16 @@ class NickClient {
   userinfo (parameters = {}) {
     return this.client.get('userinfo', parameters)
   }
+
+  /**
+   * @param  {object} [data] The data object.
+   * @param  {object} [parameters] The query parameters as an object (optional).
+   *
+   * @return {promise} The request promise.
+   */
+  createAsset(data, parameters = {}) {
+    return this.client.post('assets', data, parameters)
+  }
 }
 
 module.exports = NickClient

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -101,7 +101,7 @@ class NickClient {
    *
    * @return {promise} The request promise.
    */
-  createAsset(data, parameters = {}) {
+  createAsset (data, parameters = {}) {
     return this.client.post('assets', data, parameters)
   }
 }


### PR DESCRIPTION
This adds support for the new endpoint on nick-service which allows us to create assets. https://github.com/infopark-customers/bima-nick-service/pull/32