### PR TITLE
[fix] fix how token generator is passed to base client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-dist: focal
+dist: jammy
 language: node_js
 cache: npm
 node_js:
-  - "18"
+  - "21"
 
 before_install:
   - npm i -g standard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bima-shark-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/src/clients/asset-client.js
+++ b/src/clients/asset-client.js
@@ -15,7 +15,8 @@ class AssetClient {
     this.client = new Client({
       name: 'AssetClient',
       url: `${url}/assets`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
     this.directory = directory
   }

--- a/src/clients/base-client.js
+++ b/src/clients/base-client.js
@@ -15,6 +15,7 @@ const SharkProxy = require('../proxy')
  *   - name {string}
  *   - contentType {string}
  *   - serviceToken {object}
+ *   - getAuthToken {function}
  *
  * @throws {Error} if baseUrl is invalid
  * @throws {Error} if tokenClient cannot be instantiated
@@ -34,7 +35,7 @@ class BaseClient {
       throw new Error('Parameter `url` is missing or not a string')
     }
 
-    if (options.getAuthToken) {
+    if (options.getAuthToken && typeof options.getAuthToken === 'function') {
       this.getAuthToken = async () => await options.getAuthToken()
     } else {
       const tokenClient = new SharkProxy.ServiceTokenClient({ baseUrl: Config.serviceTokenUrl, ...options.serviceToken })

--- a/src/clients/business-app-client.js
+++ b/src/clients/business-app-client.js
@@ -7,7 +7,8 @@ class BusinessAppClient {
     this.client = new Client({
       name: 'BusinessAppClient',
       url: `${url}/api/business_apps`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/consent-changes-client.js
+++ b/src/clients/consent-changes-client.js
@@ -7,7 +7,8 @@ class ConsentChangesClient {
     this.client = new Client({
       name: 'ConsentChangesClient',
       url: `${url}/consents`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/consent-client.js
+++ b/src/clients/consent-client.js
@@ -7,7 +7,8 @@ class ConsentClient {
     this.client = new Client({
       name: 'ConsentClient',
       url: `${url}/consents`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/contact-client.js
+++ b/src/clients/contact-client.js
@@ -8,7 +8,8 @@ class ContactClient {
     this.client = new Client({
       name: 'ContactClient',
       url: `${url}/api/contacts`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/description-client.js
+++ b/src/clients/description-client.js
@@ -7,7 +7,8 @@ class DescriptionClient {
     this.client = new Client({
       name: 'DescriptionClient',
       url: `${url}/api/descriptions`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/double-opt-in/execution-client.js
+++ b/src/clients/double-opt-in/execution-client.js
@@ -7,7 +7,8 @@ class DoubleOptInExecutionClient {
     this.client = new Client({
       name: 'DoubleOptInExecutionClient',
       url: `${url}/executions`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/double-opt-in/request-client.js
+++ b/src/clients/double-opt-in/request-client.js
@@ -7,7 +7,8 @@ class DoubleOptInRequestClient {
     this.client = new Client({
       name: 'DoubleOptInRequestClient',
       url: `${url}/requests`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/group-client.js
+++ b/src/clients/group-client.js
@@ -7,7 +7,8 @@ class GroupClient {
     this.client = new Client({
       name: 'GroupClient',
       url: `${url}/api/groups`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/mailing-client.js
+++ b/src/clients/mailing-client.js
@@ -7,7 +7,8 @@ class MailingClient {
     this.client = new Client({
       name: 'MailingClient',
       url: `${url}/v1/mails`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/nick-client.js
+++ b/src/clients/nick-client.js
@@ -11,7 +11,8 @@ class NickClient {
     this.client = new Client({
       name: 'NickClient',
       url: `${url}`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/notifications-client.js
+++ b/src/clients/notifications-client.js
@@ -7,7 +7,8 @@ class NotificationsClient {
     this.client = new Client({
       name: 'NotificationsClient',
       url: `${url}/notifications`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/permission-client.js
+++ b/src/clients/permission-client.js
@@ -7,7 +7,8 @@ class PermissionClient {
     this.client = new Client({
       name: 'PermissionClient',
       url: `${url}/api/permissions`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/role-client.js
+++ b/src/clients/role-client.js
@@ -7,7 +7,8 @@ class RoleClient {
     this.client = new Client({
       name: 'RoleClient',
       url: `${url}/api/roles`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/subscription-client.js
+++ b/src/clients/subscription-client.js
@@ -7,7 +7,8 @@ class SubscriptionClient {
     this.client = new Client({
       name: 'SubscriptionClient',
       url: `${url}/subscriptions`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
   }
 

--- a/src/clients/user-client.js
+++ b/src/clients/user-client.js
@@ -8,7 +8,8 @@ class UserClient {
     this.client = new Client({
       name: 'UserClient',
       url: `${url}/api/users`,
-      serviceToken: options.serviceToken
+      serviceToken: options.serviceToken,
+      getAuthToken: options.getAuthToken
     })
     this.businessAppClient = new BusinessAppClient(url, options)
   }


### PR DESCRIPTION
it was a bug in the code, we must provide `getAuthToken` as a part of `serviceToken`, because clients pass only serviceToken part to base client. This requirement makes me think that passing generator as `serviceToken` option is better idea, see examples in readme.